### PR TITLE
Add support for additionalProperties with a schema.

### DIFF
--- a/src/onde.js
+++ b/src/onde.js
@@ -205,8 +205,8 @@ onde.Onde.prototype.renderObject = function (schema, parentNode, namespace, data
     if (schema.additionalProperties) {
         //NOTE: additionalProperties could have 4 types of value: boolean, 
         // string (the name of the type), object (type info), array of types.
+        var firstItem = rowN ? false : true;
         if (schema.additionalProperties === true) {
-            var firstItem = rowN ? false : true;
             for (var dKey in data) {
                 //NOTE: No need to check the types. Will be done by the inner renderers.
                 // Take only additional items
@@ -221,8 +221,21 @@ onde.Onde.prototype.renderObject = function (schema, parentNode, namespace, data
                     baseNode.append(rowN);
                 }
             }
+        } else if (typeof schema.additionalProperties == "object") {
+            for(var dKey in data) {
+                if(sortedKeys.indexOf(dKey) === -1) {
+                    rowN = this.renderObjectPropertyField(namespace, fieldId,
+                        schema.additionalProperties,
+                        dKey, data[dKey]);
+                }
+            }
+            if (firstItem) {
+                rowN.addClass('first');
+                firstItem = false;
+            }
+            baseNode.append(rowN);
         } else {
-            //TODO: Get the schema
+            //TODO: handle other additionalProperty values
         }
     }
     // Always the last if the object has any property

--- a/src/onde.js
+++ b/src/onde.js
@@ -221,7 +221,7 @@ onde.Onde.prototype.renderObject = function (schema, parentNode, namespace, data
                     baseNode.append(rowN);
                 }
             }
-        } else if (typeof schema.additionalProperties == "object") {
+        } else if (Object.prototype.toString.call(schema.additionalProperties) == '[object Object]') {
             for(var dKey in data) {
                 if(sortedKeys.indexOf(dKey) === -1) {
                     rowN = this.renderObjectPropertyField(namespace, fieldId,


### PR DESCRIPTION
When an object has additionalProperties specified as an object rather than a
boolean, consider the object to be the schema for any other properties in the
object instance and render it as appropriate, passing the additionalProperties
schema on to later levels.

This works fine on all the data I tried it with, correctly rendering complex hierarchies where the additionalProperties are objects that have further levels of schema. For example:

http://habitat.habhub.org/onde/samples/app.html#?schema_url=schemas/flight.json&data_url=data/flight.json
